### PR TITLE
Feat: Ability to generate lightmap UVs

### DIFF
--- a/Packages/jp.keijiro.metamesh/Editor/MetameshImporter.cs
+++ b/Packages/jp.keijiro.metamesh/Editor/MetameshImporter.cs
@@ -22,6 +22,7 @@ public sealed class MetameshImporter : ScriptedImporter
     [SerializeField] RoundedBox _roundedBox = new RoundedBox();
     [SerializeField] Ring _ring = new Ring();
     [SerializeField] Disc _disc = new Disc();
+    [SerializeField] bool _generateLightmapUVs = false;
 
     public override void OnImportAsset(AssetImportContext context)
     {
@@ -63,6 +64,7 @@ public sealed class MetameshImporter : ScriptedImporter
         }
 
         mesh.RecalculateBounds();
+        if(_generateLightmapUVs) Unwrapping.GenerateSecondaryUVSet(mesh);
         mesh.UploadMeshData(true);
 
         return mesh;

--- a/Packages/jp.keijiro.metamesh/Editor/MetameshImporterEditor.cs
+++ b/Packages/jp.keijiro.metamesh/Editor/MetameshImporterEditor.cs
@@ -20,6 +20,7 @@ sealed class MetameshImporterEditor : ScriptedImporterEditor
     SerializedProperty _roundedBox;
     SerializedProperty _ring;
     SerializedProperty _disc;
+    SerializedProperty _generateLightmapUVs;
 
     public override void OnEnable()
     {
@@ -33,6 +34,7 @@ sealed class MetameshImporterEditor : ScriptedImporterEditor
         _roundedBox = serializedObject.FindProperty("_roundedBox");
         _ring       = serializedObject.FindProperty("_ring");
         _disc       = serializedObject.FindProperty("_disc");
+        _generateLightmapUVs = serializedObject.FindProperty("_generateLightmapUVs");
     }
 
     public override void OnInspectorGUI()
@@ -52,6 +54,8 @@ sealed class MetameshImporterEditor : ScriptedImporterEditor
             case Shape.Ring      : EditorGUILayout.PropertyField(_ring);       break;
             case Shape.Disc      : EditorGUILayout.PropertyField(_disc);       break;
         }
+
+        EditorGUILayout.PropertyField(_generateLightmapUVs);
 
         serializedObject.ApplyModifiedProperties();
         ApplyRevertGUI();


### PR DESCRIPTION
Currently, the generated meshes have overlapping UVs, making them unsuitable e.g. when generating lightmaps.

This PR adds a toggle to have Unity autogenerate the lightmap UVs. This isn't ideal (probably generating a "good" second set of UVs would be better) but given that the meshes are all very small, is sufficiently fast (aka doesn't feel slower than before).